### PR TITLE
Getting TSINFO properly

### DIFF
--- a/@NicoletFile/TestNicolet.m
+++ b/@NicoletFile/TestNicolet.m
@@ -1,0 +1,6 @@
+dir = strcat(getenv('USERPROFILE'),'\Documents\GitHub\Nicolet-Reader\@NicoletFile\');
+cd(dir);
+filename= strcat(dir, 'janbrogger.e');
+obj = NicoletFile(filename);
+
+


### PR DESCRIPTION
Removes "blame Nicolet" message when reading TSINFO. Removes manual seeking for TSGUID, which is bound to be error prone. This necessitates reading "dynamic packets", which are split over several index segments.  For now, we only read the first TSINFO but there should always be one and I've never seen a TSINFO that changes between packets. Also added a test EEG and a short test script.

You may also find the dynamic packets structure useful. You can improve the reading of montages by reading the several dynamic packets of DERIVATIONGUID, instead of only the one from the static packets. This way you can read all the different montages used. Also, you can get filters (FILTERGUID), display parameters (DISPLAYGUID) etc.
