### PR TITLE
Allow reading of multiple tsPackets

### DIFF
--- a/@NicoletFile/NicoletFile.m
+++ b/@NicoletFile/NicoletFile.m
@@ -479,14 +479,15 @@ classdef NicoletFile < handle
       if length(tsPackets) > 1
           warning(['Multiple TSinfo packets detected; using first instance ' ...
             ' ac for all segments. See documentation for info.']);
-      elseif isempty(tsPackets)
-          warning(['No TSINFO found']);
+      end
+      if isempty(tsPackets)
+          warning('No TSINFO found');
       else    
           tsPacket = tsPackets(1);
 
           obj.tsInfo = struct();                  
           elems = typecast(tsPacket.data(753:756),'uint32');        
-          alloc = typecast(tsPacket.data(757:760),'uint32');        
+          %alloc = typecast(tsPacket.data(757:760),'uint32');        
 
           offset = 761;
           for i = 1:elems


### PR DESCRIPTION
Hello,

We use your very helpful reader in Brainstorm: https://neuroimage.usc.edu/brainstorm/Introduction
There are some files with multiple tsPackets I couldn't read because after displaying the message "Multiple TSinfo packets detected; using first instance...", it was skipping completely the reading of the first instance info.

This fix lets me read the file, but maybe this is completely wrong: I didn't read the code beside this specific part where I had a Matlab error (line 549, obj.tsInfo.label crashes because obj.tsInfo is empty).

Cheers
Francois